### PR TITLE
Localize ask decision UI

### DIFF
--- a/src/ask-tool.ts
+++ b/src/ask-tool.ts
@@ -14,15 +14,18 @@ import {
 } from "./ask-tool-helpers.ts";
 import { AskParamsSchema } from "./schema.ts";
 import type { AskParams } from "./types.ts";
+import { t } from "./i18n.ts";
 import { runAskFlow } from "./ui/controller.ts";
 
 export function registerAskTool(pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "ask_user",
-		label: "Ask User",
-		description: ASK_TOOL_DESCRIPTION,
-		promptSnippet:
-			"Clarify ambiguous or preference-sensitive decisions with a short interactive interview before proceeding",
+		label: t("tool.label", "Ask User"),
+		description: t("tool.description", ASK_TOOL_DESCRIPTION),
+		promptSnippet: t(
+			"tool.promptSnippet",
+			"Clarify ambiguous or preference-sensitive decisions with a short interactive interview before proceeding"
+		),
 		promptGuidelines: [...ASK_TOOL_PROMPT_GUIDELINES],
 		parameters: AskParamsSchema,
 		execute: executeAskTool,

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1,12 +1,18 @@
 export const OTHER_OPTION_VALUE = "__other__";
-export const OTHER_OPTION_LABEL = "Type your own";
-export const SUBMIT_CHOICES = ["Submit", "Elaborate", "Cancel"] as const;
-export const NO_PREVIEW_TEXT = "No preview available";
+import { t } from "../i18n.ts";
+
+export const OTHER_OPTION_LABEL = t("ui.other", "Type your own");
+export const SUBMIT_CHOICES = [
+	t("ui.submit", "Submit"),
+	t("ui.elaborate", "Elaborate"),
+	t("ui.cancel", "Cancel"),
+] as const;
+export const NO_PREVIEW_TEXT = t("ui.noPreview", "No preview available");
 export const ELABORATION_INSTRUCTION =
 	"First answer the user's noted clarification directly and concisely using the provided question and option context. Do not treat these notes as final answers. Then re-ask only the affected questions if a choice is still needed afterward. Do not jump straight to a follow-up question unless the note is already resolved.";
 export const CANCELLED_SUMMARY = "User cancelled the ask flow";
 export const SUBMITTED_SUMMARY = "User submitted the ask flow";
 export const ELABORATED_SUMMARY = "User asked for elaboration based on notes";
-export const CANCELLED_RESULT_TEXT = "Cancelled";
-export const SUBMITTED_RESULT_TEXT = "Submitted";
-export const ELABORATED_RESULT_TEXT = "Elaboration requested";
+export const CANCELLED_RESULT_TEXT = t("result.cancelled", "Cancelled");
+export const SUBMITTED_RESULT_TEXT = t("result.submitted", "Submitted");
+export const ELABORATED_RESULT_TEXT = t("result.elaborated", "Elaboration requested");

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -13,10 +13,12 @@ export const UI_DIMENSIONS = {
 	submitMinReviewWidth: 24,
 } as const;
 
+import { t } from "../i18n.ts";
+
 export const UI_TEXT = {
-	questionNoteTitle: "Note:",
-	reviewTitle: "Review answers",
-	unanswered: "→ unanswered",
-	editorPlaceholderInput: "Type answer...",
-	editorPlaceholderNote: "Add a note...",
+	questionNoteTitle: t("ui.noteTitle", "Note:"),
+	reviewTitle: t("ui.reviewTitle", "Review answers"),
+	unanswered: t("ui.unanswered", "→ unanswered"),
+	editorPlaceholderInput: t("ui.inputPlaceholder", "Type answer..."),
+	editorPlaceholderNote: t("ui.notePlaceholder", "Add a note..."),
 } as const;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,98 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) =>
+		String(params[key] ?? `{${key}}`)
+	);
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "es",
+		namespace: "pi-ask",
+		messages: {
+			"tool.label": "Preguntar al usuario",
+			"tool.description": "Herramienta interactiva de aclaración para casos en los que el siguiente paso depende de preferencias del usuario, requisitos faltantes o elegir entre varias direcciones válidas. Haz una entrevista breve y estructurada, recoge respuestas normalizadas y continúa usando esas respuestas explícitamente en vez de adivinar. Soporta preguntas de selección única, selección múltiple y panel de vista previa. Incluye siempre un `value` legible por máquina para cada opción. Usa `preview` solo cuando todas las opciones incluyan texto `preview`; las descripciones por sí solas no bastan.",
+			"tool.promptSnippet": "Aclara decisiones ambiguas o sensibles a preferencias con una entrevista interactiva corta antes de continuar",
+			"ui.other": "Escribir otra respuesta",
+			"ui.submit": "Enviar",
+			"ui.elaborate": "Aclarar",
+			"ui.cancel": "Cancelar",
+			"ui.noPreview": "No hay vista previa disponible",
+			"ui.noteTitle": "Nota:",
+			"ui.reviewTitle": "Revisar respuestas",
+			"ui.unanswered": "→ sin responder",
+			"ui.inputPlaceholder": "Escribe una respuesta...",
+			"ui.notePlaceholder": "Agrega una nota...",
+			"result.cancelled": "Cancelado",
+			"result.submitted": "Enviado",
+			"result.elaborated": "Aclaración solicitada",
+		},
+	},
+	{
+		locale: "fr",
+		namespace: "pi-ask",
+		messages: {
+			"tool.label": "Demander à l’utilisateur",
+			"tool.description": "Outil de clarification interactif pour les cas où la suite dépend des préférences de l’utilisateur, d’exigences manquantes ou d’un choix entre plusieurs directions valides. Pose un court entretien structuré, recueille des réponses normalisées, puis continue en utilisant explicitement ces réponses au lieu de deviner. Prend en charge les questions à choix unique, choix multiple et panneau d’aperçu. Inclue toujours une valeur `value` lisible par machine pour chaque option. Utilise `preview` uniquement si chaque option contient un texte `preview`; les descriptions seules ne suffisent pas.",
+			"tool.promptSnippet": "Clarifie les décisions ambiguës ou sensibles aux préférences avec un court entretien interactif avant de continuer",
+			"ui.other": "Écrire une autre réponse",
+			"ui.submit": "Envoyer",
+			"ui.elaborate": "Clarifier",
+			"ui.cancel": "Annuler",
+			"ui.noPreview": "Aucun aperçu disponible",
+			"ui.noteTitle": "Note :",
+			"ui.reviewTitle": "Vérifier les réponses",
+			"ui.unanswered": "→ sans réponse",
+			"ui.inputPlaceholder": "Saisir une réponse...",
+			"ui.notePlaceholder": "Ajouter une note...",
+			"result.cancelled": "Annulé",
+			"result.submitted": "Envoyé",
+			"result.elaborated": "Clarification demandée",
+		},
+	},
+	{
+		locale: "pt-BR",
+		namespace: "pi-ask",
+		messages: {
+			"tool.label": "Perguntar ao usuário",
+			"tool.description": "Ferramenta interativa de esclarecimento para casos em que o próximo passo depende de preferências do usuário, requisitos ausentes ou escolha entre várias direções válidas. Faça uma entrevista curta e estruturada, colete respostas normalizadas e continue usando essas respostas explicitamente em vez de adivinhar. Suporta perguntas de seleção única, seleção múltipla e painel de prévia. Sempre inclua um `value` legível por máquina para cada opção. Use `preview` somente quando todas as opções tiverem texto `preview`; descrições sozinhas não bastam.",
+			"tool.promptSnippet": "Esclareça decisões ambíguas ou sensíveis a preferências com uma entrevista interativa curta antes de continuar",
+			"ui.other": "Digitar outra resposta",
+			"ui.submit": "Enviar",
+			"ui.elaborate": "Esclarecer",
+			"ui.cancel": "Cancelar",
+			"ui.noPreview": "Nenhuma prévia disponível",
+			"ui.noteTitle": "Nota:",
+			"ui.reviewTitle": "Revisar respostas",
+			"ui.unanswered": "→ sem resposta",
+			"ui.inputPlaceholder": "Digite uma resposta...",
+			"ui.notePlaceholder": "Adicionar uma nota...",
+			"result.cancelled": "Cancelado",
+			"result.submitted": "Enviado",
+			"result.elaborated": "Esclarecimento solicitado",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "pi-ask",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerAskSettingsCommand } from "./ask-settings-command.ts";
 import { registerAskTool } from "./ask-tool.ts";
+import { initI18n } from "./i18n.ts";
 
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CONFIGURATION_DOC_PATH = resolve(
@@ -13,6 +14,7 @@ const CONFIGURATION_DOC_PATH = resolve(
 const PI_ASK_CONFIG_PROMPT = `When the user asks to configure, customize, debug, or explain @eko24ive/pi-ask settings or keymaps, first read ${CONFIGURATION_DOC_PATH} and follow it as the source of truth before editing config files.`;
 
 export default function askExtension(pi: ExtensionAPI) {
+	initI18n(pi);
 	pi.on("before_agent_start", async (event) => ({
 		systemPrompt: `${event.systemPrompt}\n\n${PI_ASK_CONFIG_PROMPT}`,
 	}));


### PR DESCRIPTION
I found one small UX issue: ask_user is a decision point where users choose answers, add notes, elaborate, submit, or cancel. If those labels are misread, the agent can continue with the wrong direction.

This PR makes that decision surface optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: es, fr, pt-BR — Western default per broad developer/HITL workflow fit
- Covers tool label/description, prompt snippet, submit actions, custom answer label, review text, placeholders, and result labels

Validation:
- npm install --ignore-scripts
- npx tsc --noEmit
- npm pack --dry-run

Note: npm test is currently blocked locally on Node 20/Windows because node --test cannot load .ts test files directly and the package script passes tests/*.test.ts without a loader. I left that environment issue out of the implementation path.