### PR TITLE
Support Ctrl-N and Ctrl-P option navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ It lets an agent pause, ask structured questions in a terminal UI, and continue 
 
 https://github.com/user-attachments/assets/a8503ca9-afcb-4c31-9edc-353b985a0209
 
-
 ## Install
 
 ```bash
@@ -46,51 +45,61 @@ Once installed, this package gives the agent a native way to ask for clarificati
 ## Feature walkthrough
 
 ### Multi-question flow (tabs)
+
 Move across several related questions in one ask flow.
 
 ![Multi-question ask_user flow with tab navigation](docs/media/feature-multi-question-tabs.png)
 
 ### Single-select question
+
 Pick one option when answers are mutually exclusive.
 
 ![Single-select question with one selected option](docs/media/feature-single-select.png)
 
 ### Multi-select question
+
 Choose multiple options when several answers apply.
 
 ![Multi-select question with multiple selected options](docs/media/feature-multi-select.png)
 
 ### Preview mode
+
 Use a dedicated preview pane when options need richer detail.
 
 ![Preview question showing a dedicated preview pane](docs/media/feature-preview-pane.png)
 
 ### Custom answer (`Type your own`)
+
 Capture free-form input inline without leaving the flow.
 
 ![Inline custom answer input for Type your own option](docs/media/feature-custom-answer-input.png)
 
 ### Native `@` file references
+
 Use pi-style `@` file path autocomplete inside free-form answers and note editors.
 
 ![Native pi-style @ file references inside the ask flow](docs/media/feature-at-file-mentions.png)
 
 ### Option notes
+
 Attach clarification notes to a specific option (`n`).
 
 ![Option note editor with note text for selected option](docs/media/feature-option-note.png)
 
 ### Question notes
+
 Add notes at question level for broader context (`Shift+N`).
 
 ![Question-level note editor with saved note](docs/media/feature-question-note.png)
 
 ### Review tab — Submit
+
 Review all answers before returning them to the agent.
 
 ![Review tab with Submit action highlighted](docs/media/feature-review-submit.png)
 
 ### Review tab — Elaborate
+
 Ask the agent to elaborate on notes before finalizing choices.
 
 ![Review tab with Elaborate action and expanded note preview](docs/media/feature-review-elaborate.png)
@@ -101,29 +110,31 @@ Open ask settings with `?` during the ask flow, or with the `/ask-settings` comm
 
 Customizable via config:
 
-| Action | Default key |
-|---|---|
-| Cancel flow or close/save editor draft | `Esc` |
-| Dismiss entire ask flow immediately | `Ctrl+C` |
-| Toggle selected option | `Space` |
-| Confirm / continue / save / submit | `Enter` |
-| Edit selected option note | `n` |
-| Edit question note | `Shift+N` |
-| Move to previous option/action | `↑` |
-| Move to next option/action | `↓` |
+| Action                                 | Default key |
+| -------------------------------------- | ----------- |
+| Cancel flow or close/save editor draft | `Esc`       |
+| Dismiss entire ask flow immediately    | `Ctrl+C`    |
+| Toggle selected option                 | `Space`     |
+| Confirm / continue / save / submit     | `Enter`     |
+| Edit selected option note              | `n`         |
+| Edit question note                     | `Shift+N`   |
+| Move to previous option/action         | `↑`         |
+| Move to next option/action             | `↓`         |
+
+`previousOption` and `nextOption` add aliases. `↑` and `↓` always continue to move between options.
 
 Fixed bindings:
 
-| Key                         | Context                                 | Effect                                      |
-|-----------------------------|-----------------------------------------|---------------------------------------------|
-| `?`                         | Ask flow / empty editor                 | Open ask settings                           |
-| `Tab` `Shift+Tab`           | Main flow                               | Switch tabs                                 |
-| `←` `→`                     | Main flow                               | Switch tabs                                 |
-| `1..9`                      | Options list                            | Select or toggle matching option            |
-| `1` `2` `3`                 | Review tab                              | Trigger `Submit` / `Elaborate` / `Cancel`   |
-| `↑` `↓`                     | Review tab                              | Change highlighted review action            |
-| `Tab` `Shift+Tab` / `←` `→` | Empty editor                            | Switch tabs without closing editor          |
-| Arrow keys / `Tab`          | Non-empty editor                        | Stay in editor for cursor movement          |
+| Key                         | Context                 | Effect                                    |
+| --------------------------- | ----------------------- | ----------------------------------------- |
+| `?`                         | Ask flow / empty editor | Open ask settings                         |
+| `Tab` `Shift+Tab`           | Main flow               | Switch tabs                               |
+| `←` `→`                     | Main flow               | Switch tabs                               |
+| `1..9`                      | Options list            | Select or toggle matching option          |
+| `1` `2` `3`                 | Review tab              | Trigger `Submit` / `Elaborate` / `Cancel` |
+| `↑` `↓`                     | Review tab              | Change highlighted review action          |
+| `Tab` `Shift+Tab` / `←` `→` | Empty editor            | Switch tabs without closing editor        |
+| Arrow keys / `Tab`          | Non-empty editor        | Stay in editor for cursor movement        |
 
 Review-tab shortcuts can optionally require the same number key twice via `behaviour.doublePressReviewShortcuts`.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Customizable via config:
 | Confirm / continue / save / submit | `Enter` |
 | Edit selected option note | `n` |
 | Edit question note | `Shift+N` |
+| Move to previous option/action | `↑` |
+| Move to next option/action | `↓` |
 
 Fixed bindings:
 
@@ -117,11 +119,9 @@ Fixed bindings:
 | `?`                         | Ask flow / empty editor                 | Open ask settings                           |
 | `Tab` `Shift+Tab`           | Main flow                               | Switch tabs                                 |
 | `←` `→`                     | Main flow                               | Switch tabs                                 |
-| `Ctrl+P` `Ctrl+N` / `↑` `↓` | Main flow                               | Move cursor                                 |
 | `1..9`                      | Options list                            | Select or toggle matching option            |
 | `1` `2` `3`                 | Review tab                              | Trigger `Submit` / `Elaborate` / `Cancel`   |
 | `↑` `↓`                     | Review tab                              | Change highlighted review action            |
-| `Ctrl+P` `Ctrl+N` / `↑` `↓` | Empty editor                            | Move options without closing editor         |
 | `Tab` `Shift+Tab` / `←` `→` | Empty editor                            | Switch tabs without closing editor          |
 | Arrow keys / `Tab`          | Non-empty editor                        | Stay in editor for cursor movement          |
 
@@ -155,7 +155,9 @@ You can edit this file yourself, ask pi to edit it for you, or use `/ask-setting
     "toggle": "space",
     "confirm": "enter",
     "optionNote": "n",
-    "questionNote": "shift+n"
+    "questionNote": "shift+n",
+    "previousOption": "up",
+    "nextOption": "down"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Fixed bindings:
 | `?`                         | Ask flow / empty editor                 | Open ask settings                           |
 | `Tab` `Shift+Tab`           | Main flow                               | Switch tabs                                 |
 | `←` `→`                     | Main flow                               | Switch tabs                                 |
-| `↑` `↓`                     | Main flow                               | Move cursor                                 |
+| `Ctrl+P` `Ctrl+N` / `↑` `↓` | Main flow                               | Move cursor                                 |
 | `1..9`                      | Options list                            | Select or toggle matching option            |
 | `1` `2` `3`                 | Review tab                              | Trigger `Submit` / `Elaborate` / `Cancel`   |
 | `↑` `↓`                     | Review tab                              | Change highlighted review action            |
-| `↑` `↓`                     | Empty editor                            | Move options without closing editor         |
+| `Ctrl+P` `Ctrl+N` / `↑` `↓` | Empty editor                            | Move options without closing editor         |
 | `Tab` `Shift+Tab` / `←` `→` | Empty editor                            | Switch tabs without closing editor          |
 | Arrow keys / `Tab`          | Non-empty editor                        | Stay in editor for cursor movement          |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,8 @@ Each configurable action accepts any single `pi-tui` key id string, as long as i
 - not reserved
 - not duplicated across configurable actions
 
+`previousOption` and `nextOption` add aliases. `up` and `down` always continue to move between options. Keep the defaults if you want the footer to show only `↑/↓`.
+
 Examples of valid bindings:
 
 - `esc`
@@ -178,6 +180,8 @@ These bindings are fixed and cannot be used by configurable actions:
 - `shift+tab`
 - `left`
 - `right`
+- `up`, except as the default `previousOption`
+- `down`, except as the default `nextOption`
 - `1`
 - `2`
 - `3`
@@ -194,6 +198,7 @@ These are intentionally not configurable:
 
 - `?` opens ask settings
 - `tab`, `shift+tab`, `left`, `right` move between tabs
+- `up`, `down` move between options, even when option navigation aliases are configured
 - `1..9` triggers option/review shortcuts
 - when `behaviour.doublePressReviewShortcuts` is enabled, review-tab shortcuts `1`, `2`, and `3` require the same key twice
 - `@` remains file-reference affordance in editors
@@ -222,9 +227,7 @@ Invalid keymaps include:
   "answer": {
     "extractionRetries": 1,
     "extractionTimeoutMs": 30000,
-    "extractionModels": [
-      { "provider": "openai-codex", "id": "gpt-5.4-mini" }
-    ]
+    "extractionModels": [{ "provider": "openai-codex", "id": "gpt-5.4-mini" }]
   },
   "behaviour": {
     "autoSubmitWhenAnsweredWithoutNotes": true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,9 @@ Unsupported future versions or invalid files are backed up and defaults are load
     "toggle": "space",
     "confirm": "enter",
     "optionNote": "n",
-    "questionNote": "shift+n"
+    "questionNote": "shift+n",
+    "previousOption": "up",
+    "nextOption": "down"
   }
 }
 ```
@@ -109,7 +111,7 @@ These settings affect only the `/answer` command. Normal `ask_user` tool calls d
 
 ## Keymaps
 
-`keymaps` must contain all 6 configurable actions if present.
+`keymaps` can override any configurable action. Missing actions use defaults.
 
 ### Configurable actions
 
@@ -119,6 +121,8 @@ These settings affect only the `/answer` command. Normal `ask_user` tool calls d
 - `confirm`
 - `optionNote`
 - `questionNote`
+- `previousOption`
+- `nextOption`
 
 ### Defaults
 
@@ -128,6 +132,8 @@ These settings affect only the `/answer` command. Normal `ask_user` tool calls d
 - `confirm: "enter"`
 - `optionNote: "n"`
 - `questionNote: "shift+n"`
+- `previousOption: "up"`
+- `nextOption: "down"`
 
 ### Allowed bindings
 
@@ -172,8 +178,6 @@ These bindings are fixed and cannot be used by configurable actions:
 - `shift+tab`
 - `left`
 - `right`
-- `up`
-- `down`
 - `1`
 - `2`
 - `3`
@@ -190,7 +194,6 @@ These are intentionally not configurable:
 
 - `?` opens ask settings
 - `tab`, `shift+tab`, `left`, `right` move between tabs
-- `ctrl+p`/`up` and `ctrl+n`/`down` move between options/actions
 - `1..9` triggers option/review shortcuts
 - when `behaviour.doublePressReviewShortcuts` is enabled, review-tab shortcuts `1`, `2`, and `3` require the same key twice
 - `@` remains file-reference affordance in editors
@@ -207,7 +210,6 @@ If configured keymaps are invalid:
 
 Invalid keymaps include:
 
-- missing one of the 6 required actions
 - unsupported key syntax
 - duplicate bindings across configurable actions
 - use of reserved bindings
@@ -236,7 +238,9 @@ Invalid keymaps include:
     "toggle": "ctrl+t",
     "confirm": "ctrl+k",
     "optionNote": "x",
-    "questionNote": "shift+x"
+    "questionNote": "shift+x",
+    "previousOption": "ctrl+p",
+    "nextOption": "ctrl+n"
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,7 +190,7 @@ These are intentionally not configurable:
 
 - `?` opens ask settings
 - `tab`, `shift+tab`, `left`, `right` move between tabs
-- `up`, `down` move between options/actions
+- `ctrl+p`/`up` and `ctrl+n`/`down` move between options/actions
 - `1..9` triggers option/review shortcuts
 - when `behaviour.doublePressReviewShortcuts` is enabled, review-tab shortcuts `1`, `2`, and `3` require the same key twice
 - `@` remains file-reference affordance in editors

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -90,6 +90,8 @@ export function toAskConfigFileV2(config: AskConfig): AskConfigFileV2 {
 			confirm: normalized.keymaps.confirm,
 			optionNote: normalized.keymaps.optionNote,
 			questionNote: normalized.keymaps.questionNote,
+			previousOption: normalized.keymaps.previousOption,
+			nextOption: normalized.keymaps.nextOption,
 		},
 	};
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,8 @@ export const AskConfigFileV2Schema = Type.Object({
 			dismiss: Type.Optional(Type.String()),
 			optionNote: Type.Optional(Type.String()),
 			questionNote: Type.Optional(Type.String()),
+			nextOption: Type.Optional(Type.String()),
+			previousOption: Type.Optional(Type.String()),
 			toggle: Type.Optional(Type.String()),
 		})
 	),
@@ -54,7 +56,9 @@ export interface AskConfigKeymaps {
 	cancel: string;
 	confirm: string;
 	dismiss: string;
+	nextOption: string;
 	optionNote: string;
+	previousOption: string;
 	questionNote: string;
 	toggle: string;
 }

--- a/src/constants/keymaps.ts
+++ b/src/constants/keymaps.ts
@@ -177,14 +177,14 @@ const FIXED_BINDING_METADATA: readonly FixedBindingMetadata[] = [
 	},
 	{
 		id: "previousOption",
-		keys: [Key.up],
+		keys: [Key.ctrl("p"), Key.up],
 		kind: "command",
-		description: "Move between options/actions",
+		description: "Move to previous option/action",
 		contexts: ["Main flow", "Empty editor"],
 	},
 	{
 		id: "nextOption",
-		keys: [Key.down],
+		keys: [Key.ctrl("n"), Key.down],
 		kind: "command",
 		description: "Move to next option/action",
 		contexts: ["Main flow", "Empty editor"],

--- a/src/constants/keymaps.ts
+++ b/src/constants/keymaps.ts
@@ -43,8 +43,6 @@ const RESERVED_CONFIGURABLE_BINDINGS = new Set([
 	"shift+tab",
 	"left",
 	"right",
-	"up",
-	"down",
 	"1",
 	"2",
 	"3",
@@ -58,8 +56,6 @@ const RESERVED_CONFIGURABLE_BINDINGS = new Set([
 const ACTION_LABEL_OVERRIDES: Partial<Record<AskKeyBindingId, string>> = {
 	nextTab: "Tab / →",
 	previousTab: "Shift+Tab / ←",
-	previousOption: "↑ / ↓",
-	nextOption: "↓",
 	numberShortcut: "1..9",
 };
 
@@ -83,8 +79,6 @@ export type AskFixedKeyBindingId =
 	| "settings"
 	| "nextTab"
 	| "previousTab"
-	| "previousOption"
-	| "nextOption"
 	| "numberShortcut"
 	| "fileReference";
 export type AskKeyBindingId = AskConfigurableKeyAction | AskFixedKeyBindingId;
@@ -112,6 +106,8 @@ export const DEFAULT_ASK_KEYMAPS: AskConfigKeymaps = {
 	confirm: "enter",
 	optionNote: "n",
 	questionNote: "shift+n",
+	previousOption: "up",
+	nextOption: "down",
 };
 
 const CONFIGURABLE_BINDING_METADATA: readonly ConfigurableBindingMetadata[] = [
@@ -151,6 +147,18 @@ const CONFIGURABLE_BINDING_METADATA: readonly ConfigurableBindingMetadata[] = [
 		description: "Edit question note",
 		contexts: ["Question tabs"],
 	},
+	{
+		id: "previousOption",
+		kind: "command",
+		description: "Move to previous option/action",
+		contexts: ["Main flow", "Empty editor"],
+	},
+	{
+		id: "nextOption",
+		kind: "command",
+		description: "Move to next option/action",
+		contexts: ["Main flow", "Empty editor"],
+	},
 ] as const;
 
 const FIXED_BINDING_METADATA: readonly FixedBindingMetadata[] = [
@@ -173,20 +181,6 @@ const FIXED_BINDING_METADATA: readonly FixedBindingMetadata[] = [
 		keys: [Key.shift("tab"), Key.left],
 		kind: "command",
 		description: "Switch to previous tab",
-		contexts: ["Main flow", "Empty editor"],
-	},
-	{
-		id: "previousOption",
-		keys: [Key.ctrl("p"), Key.up],
-		kind: "command",
-		description: "Move to previous option/action",
-		contexts: ["Main flow", "Empty editor"],
-	},
-	{
-		id: "nextOption",
-		keys: [Key.ctrl("n"), Key.down],
-		kind: "command",
-		description: "Move to next option/action",
 		contexts: ["Main flow", "Empty editor"],
 	},
 	{
@@ -219,10 +213,21 @@ export function formatKeybindingLabel(key: string): string {
 			if (part.length <= 1) {
 				return part.toUpperCase();
 			}
-			if (part === "pageUp" || part === "pageDown") {
-				return part;
+			switch (part) {
+				case "up":
+					return "↑";
+				case "down":
+					return "↓";
+				case "left":
+					return "←";
+				case "right":
+					return "→";
+				case "pageUp":
+				case "pageDown":
+					return part;
+				default:
+					return part.charAt(0).toUpperCase() + part.slice(1);
 			}
-			return part.charAt(0).toUpperCase() + part.slice(1);
 		})
 		.join("+");
 }
@@ -250,6 +255,8 @@ export function getAskKeyBindings(
 		confirm: createCustomizableBinding(config, "confirm"),
 		optionNote: createCustomizableBinding(config, "optionNote"),
 		questionNote: createCustomizableBinding(config, "questionNote"),
+		previousOption: createCustomizableBinding(config, "previousOption"),
+		nextOption: createCustomizableBinding(config, "nextOption"),
 	};
 	const fixed = Object.fromEntries(
 		FIXED_BINDING_METADATA.map((binding) => [
@@ -287,10 +294,7 @@ export function renderFooterKeymaps(
 	context: FooterKeymapContext
 ): string {
 	const bindings = getAskKeyBindings(config);
-	const optionNavigationLabel = bindings.previousOption.label.replaceAll(
-		" / ",
-		""
-	);
+	const optionNavigationLabel = `${bindings.previousOption.label}/${bindings.nextOption.label}`;
 	const tabNavigationLabel = "⇆";
 	const noteNavigationLabel = `${bindings.optionNote.label}/${bindings.questionNote.label}`;
 	const hintsByContext: Record<FooterKeymapContext, readonly string[]> = {
@@ -343,9 +347,9 @@ export function normalizeConfiguredKeymaps(
 	for (const action of Object.keys(
 		DEFAULT_ASK_KEYMAPS
 	) as AskConfigurableKeyAction[]) {
-		const rawValue = keymaps[action];
+		const rawValue = keymaps[action] ?? DEFAULT_ASK_KEYMAPS[action];
 		if (typeof rawValue !== "string") {
-			return { ok: false, error: `Missing keymap for ${action}.` };
+			return { ok: false, error: `Invalid keymap for ${action}: missing key` };
 		}
 		const parsed = normalizeKeyId(rawValue);
 		if (!parsed.ok) {

--- a/src/constants/keymaps.ts
+++ b/src/constants/keymaps.ts
@@ -53,6 +53,10 @@ const RESERVED_CONFIGURABLE_BINDINGS = new Set([
 	"8",
 	"9",
 ]);
+const BUILT_IN_OPTION_NAVIGATION_KEYS = {
+	previousOption: "up",
+	nextOption: "down",
+} as const;
 const ACTION_LABEL_OVERRIDES: Partial<Record<AskKeyBindingId, string>> = {
 	nextTab: "Tab / →",
 	previousTab: "Shift+Tab / ←",
@@ -294,7 +298,7 @@ export function renderFooterKeymaps(
 	context: FooterKeymapContext
 ): string {
 	const bindings = getAskKeyBindings(config);
-	const optionNavigationLabel = `${bindings.previousOption.label}/${bindings.nextOption.label}`;
+	const optionNavigationLabel = formatOptionNavigationLabel(bindings);
 	const tabNavigationLabel = "⇆";
 	const noteNavigationLabel = `${bindings.optionNote.label}/${bindings.questionNote.label}`;
 	const hintsByContext: Record<FooterKeymapContext, readonly string[]> = {
@@ -358,11 +362,8 @@ export function normalizeConfiguredKeymaps(
 				error: `Invalid keymap for ${action}: ${parsed.error}`,
 			};
 		}
-		if (RESERVED_CONFIGURABLE_BINDINGS.has(parsed.keyId)) {
-			return {
-				ok: false,
-				error: `Reserved keymap for ${action}: ${formatKeybindingLabel(parsed.keyId)}.`,
-			};
+		if (isReservedConfigurableKey(action, parsed.keyId)) {
+			return reservedKeymapError(action, parsed.keyId);
 		}
 		normalized[action] = parsed.keyId;
 	}
@@ -438,12 +439,72 @@ function createCustomizableBinding(
 	if (!binding) {
 		throw new Error(`Unknown customizable ask key binding: ${id}`);
 	}
-	const key = config.keymaps[id];
+	const configuredKey = config.keymaps[id];
+	const keys = [
+		...(id === "previousOption"
+			? [BUILT_IN_OPTION_NAVIGATION_KEYS.previousOption]
+			: []),
+		...(id === "nextOption"
+			? [BUILT_IN_OPTION_NAVIGATION_KEYS.nextOption]
+			: []),
+		configuredKey,
+	];
+	const uniqueBindingKeys = uniqueKeys(keys);
 	return {
 		...binding,
-		keys: [key],
-		label: formatKeybindingLabel(key),
+		keys: uniqueBindingKeys,
+		label: uniqueBindingKeys.map(formatKeybindingLabel).join("/"),
 	};
+}
+
+function uniqueKeys(keys: readonly string[]): readonly InputKey[] {
+	return [...new Set(keys)] as readonly InputKey[];
+}
+
+function formatOptionNavigationLabel(
+	bindings: Record<AskKeyBindingId, AskKeyBinding>
+): string {
+	return uniqueKeys([
+		BUILT_IN_OPTION_NAVIGATION_KEYS.previousOption,
+		BUILT_IN_OPTION_NAVIGATION_KEYS.nextOption,
+		...bindings.previousOption.keys.map(String),
+		...bindings.nextOption.keys.map(String),
+	])
+		.map(formatKeybindingLabel)
+		.join("/");
+}
+
+function isReservedConfigurableKey(
+	action: AskConfigurableKeyAction,
+	keyId: string
+): boolean {
+	return (
+		RESERVED_CONFIGURABLE_BINDINGS.has(keyId) ||
+		isReservedOptionNavigationKey(action, keyId)
+	);
+}
+
+function reservedKeymapError(
+	action: AskConfigurableKeyAction,
+	keyId: string
+): { ok: false; error: string } {
+	return {
+		ok: false,
+		error: `Reserved keymap for ${action}: ${formatKeybindingLabel(keyId)}.`,
+	};
+}
+
+function isReservedOptionNavigationKey(
+	action: AskConfigurableKeyAction,
+	keyId: string
+): boolean {
+	if (keyId === "up") {
+		return action !== "previousOption";
+	}
+	if (keyId === "down") {
+		return action !== "nextOption";
+	}
+	return false;
 }
 
 function normalizeModifierName(part: string): ModifierName | undefined {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -188,7 +188,7 @@ test("question mark opens ask settings outside non-empty editors", () => {
 	});
 });
 
-test("navigation mode uses configured option movement keymaps", () => {
+test("navigation mode uses configured option movement keymaps with arrow aliases", () => {
 	const navigation = createInitialState({
 		questions: [
 			{
@@ -216,10 +216,41 @@ test("navigation mode uses configured option movement keymaps", () => {
 		delta: 1,
 	});
 	assert.deepEqual(getInputCommand(navigation, config, "\x1b[A"), {
-		kind: "ignore",
+		kind: "moveOption",
+		delta: -1,
 	});
 	assert.deepEqual(getInputCommand(navigation, config, "\x1b[B"), {
-		kind: "ignore",
+		kind: "moveOption",
+		delta: 1,
+	});
+});
+
+test("empty editors use configured option movement keymaps with arrow aliases", () => {
+	const input = inputState();
+	const config = {
+		...DEFAULT_ASK_CONFIG,
+		keymaps: {
+			...DEFAULT_ASK_CONFIG.keymaps,
+			previousOption: "ctrl+p",
+			nextOption: "ctrl+n",
+		},
+	};
+
+	assert.deepEqual(getInputCommand(input, config, "\x10", ""), {
+		kind: "editMoveOption",
+		delta: -1,
+	});
+	assert.deepEqual(getInputCommand(input, config, "\x0e", ""), {
+		kind: "editMoveOption",
+		delta: 1,
+	});
+	assert.deepEqual(getInputCommand(input, config, "\x1b[A", ""), {
+		kind: "editMoveOption",
+		delta: -1,
+	});
+	assert.deepEqual(getInputCommand(input, config, "\x1b[B", ""), {
+		kind: "editMoveOption",
+		delta: 1,
 	});
 });
 

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -22,14 +22,22 @@ function inputState() {
 	return state;
 }
 
-test("empty typing mode uses arrows and tab for navigation", () => {
+test("empty typing mode uses arrows, Ctrl-P, Ctrl-N, and tab for navigation", () => {
 	const input = inputState();
 
 	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x1b[A", ""), {
 		kind: "editMoveOption",
 		delta: -1,
 	});
+	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x10", ""), {
+		kind: "editMoveOption",
+		delta: -1,
+	});
 	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x1b[B", ""), {
+		kind: "editMoveOption",
+		delta: 1,
+	});
+	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x0e", ""), {
 		kind: "editMoveOption",
 		delta: 1,
 	});
@@ -74,7 +82,7 @@ test("non-empty typing mode keeps arrows and tab in editor", () => {
 	});
 });
 
-test("empty note editing mode uses arrows and tab for navigation", () => {
+test("empty note editing mode uses arrows, Ctrl-P, Ctrl-N, and tab for navigation", () => {
 	const state = enterQuestionNoteMode(
 		createInitialState({
 			questions: [
@@ -92,7 +100,15 @@ test("empty note editing mode uses arrows and tab for navigation", () => {
 		kind: "editMoveOption",
 		delta: -1,
 	});
+	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x10", ""), {
+		kind: "editMoveOption",
+		delta: -1,
+	});
 	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x1b[B", ""), {
+		kind: "editMoveOption",
+		delta: 1,
+	});
+	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x0e", ""), {
 		kind: "editMoveOption",
 		delta: 1,
 	});
@@ -185,6 +201,27 @@ test("question mark opens ask settings outside non-empty editors", () => {
 	});
 	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "?", "x"), {
 		kind: "delegateToEditor",
+	});
+});
+
+test("navigation mode uses Ctrl-P and Ctrl-N for option movement", () => {
+	const navigation = createInitialState({
+		questions: [
+			{
+				id: "q1",
+				prompt: "Question?",
+				options: [{ value: "a", label: "A" }],
+			},
+		],
+	});
+
+	assert.deepEqual(getInputCommand(navigation, DEFAULT_ASK_CONFIG, "\x10"), {
+		kind: "moveOption",
+		delta: -1,
+	});
+	assert.deepEqual(getInputCommand(navigation, DEFAULT_ASK_CONFIG, "\x0e"), {
+		kind: "moveOption",
+		delta: 1,
 	});
 });
 

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -22,22 +22,14 @@ function inputState() {
 	return state;
 }
 
-test("empty typing mode uses arrows, Ctrl-P, Ctrl-N, and tab for navigation", () => {
+test("empty typing mode uses arrows and tab for navigation", () => {
 	const input = inputState();
 
 	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x1b[A", ""), {
 		kind: "editMoveOption",
 		delta: -1,
 	});
-	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x10", ""), {
-		kind: "editMoveOption",
-		delta: -1,
-	});
 	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x1b[B", ""), {
-		kind: "editMoveOption",
-		delta: 1,
-	});
-	assert.deepEqual(getInputCommand(input, DEFAULT_ASK_CONFIG, "\x0e", ""), {
 		kind: "editMoveOption",
 		delta: 1,
 	});
@@ -82,7 +74,7 @@ test("non-empty typing mode keeps arrows and tab in editor", () => {
 	});
 });
 
-test("empty note editing mode uses arrows, Ctrl-P, Ctrl-N, and tab for navigation", () => {
+test("empty note editing mode uses arrows and tab for navigation", () => {
 	const state = enterQuestionNoteMode(
 		createInitialState({
 			questions: [
@@ -100,15 +92,7 @@ test("empty note editing mode uses arrows, Ctrl-P, Ctrl-N, and tab for navigatio
 		kind: "editMoveOption",
 		delta: -1,
 	});
-	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x10", ""), {
-		kind: "editMoveOption",
-		delta: -1,
-	});
 	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x1b[B", ""), {
-		kind: "editMoveOption",
-		delta: 1,
-	});
-	assert.deepEqual(getInputCommand(state, DEFAULT_ASK_CONFIG, "\x0e", ""), {
 		kind: "editMoveOption",
 		delta: 1,
 	});
@@ -204,7 +188,7 @@ test("question mark opens ask settings outside non-empty editors", () => {
 	});
 });
 
-test("navigation mode uses Ctrl-P and Ctrl-N for option movement", () => {
+test("navigation mode uses configured option movement keymaps", () => {
 	const navigation = createInitialState({
 		questions: [
 			{
@@ -214,14 +198,28 @@ test("navigation mode uses Ctrl-P and Ctrl-N for option movement", () => {
 			},
 		],
 	});
+	const config = {
+		...DEFAULT_ASK_CONFIG,
+		keymaps: {
+			...DEFAULT_ASK_CONFIG.keymaps,
+			previousOption: "ctrl+p",
+			nextOption: "ctrl+n",
+		},
+	};
 
-	assert.deepEqual(getInputCommand(navigation, DEFAULT_ASK_CONFIG, "\x10"), {
+	assert.deepEqual(getInputCommand(navigation, config, "\x10"), {
 		kind: "moveOption",
 		delta: -1,
 	});
-	assert.deepEqual(getInputCommand(navigation, DEFAULT_ASK_CONFIG, "\x0e"), {
+	assert.deepEqual(getInputCommand(navigation, config, "\x0e"), {
 		kind: "moveOption",
 		delta: 1,
+	});
+	assert.deepEqual(getInputCommand(navigation, config, "\x1b[A"), {
+		kind: "ignore",
+	});
+	assert.deepEqual(getInputCommand(navigation, config, "\x1b[B"), {
+		kind: "ignore",
 	});
 });
 

--- a/tests/render-frame.test.ts
+++ b/tests/render-frame.test.ts
@@ -253,7 +253,7 @@ test("footer keeps earlier hint chunk on the first wrapped line", () => {
 		editor: mockEditor(),
 	});
 
-	assert.equal(lines.at(-6), " ⇆ tab · ↑↓ select");
+	assert.equal(lines.at(-6), " ⇆ tab · ↑/↓ select");
 	assert.deepEqual(lines.slice(-5, -1), [
 		"Enter confirm",
 		"N/Shift+N note",

--- a/tests/render-helpers.test.ts
+++ b/tests/render-helpers.test.ts
@@ -100,3 +100,19 @@ test("editing footers use configured key labels", () => {
 		" Ctrl+K save · Q close · ? settings"
 	);
 });
+
+test("navigation footers show arrows and configured option aliases", () => {
+	const config = {
+		...DEFAULT_ASK_CONFIG,
+		keymaps: {
+			...DEFAULT_ASK_CONFIG.keymaps,
+			previousOption: "ctrl+p",
+			nextOption: "ctrl+n",
+		},
+	};
+
+	assert.equal(
+		renderFooterText(config, "default"),
+		" ⇆ tab · ↑/↓/Ctrl+P/Ctrl+N select · Enter confirm · N/Shift+N note · Esc dismiss · ? settings"
+	);
+});

--- a/tests/settings-list.test.ts
+++ b/tests/settings-list.test.ts
@@ -22,6 +22,8 @@ const savedConfig: AskConfig = {
 		confirm: "enter",
 		optionNote: "n",
 		questionNote: "shift+n",
+		previousOption: "up",
+		nextOption: "down",
 	},
 };
 


### PR DESCRIPTION
## Summary

Adds Ctrl-P and Ctrl-N as fixed option navigation aliases. Arrow keys still work.

## Changes

- Use Ctrl-P for previous option and Ctrl-N for next option
- Keep Up and Down arrow navigation unchanged
- Update README and configuration docs
- Add input tests for navigation, empty input editors, and empty note editors

## Test

```bash
corepack pnpm check
corepack pnpm test
corepack pnpm typecheck
```