### PR TITLE
feat: emit ask:started and ask:completed events on pi.events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,7 @@ The codebase is split so the implementation reads through file boundaries and na
 - when the ask config file is missing, the first ask use writes a default persisted config snapshot under `~/.pi/agent/extensions/`
 - legacy root config files move into `~/.pi/agent/extensions/` only when the current config file is absent
 - live config updates can affect an in-progress ask flow immediately
+- `ask:started` and `ask:completed` events are emitted on `pi.events` at flow boundaries in `ask-tool.ts` and `answer-commands.ts`; they are always paired and never emitted on validation failure or in non-interactive mode
 
 ## Documentation rule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ The codebase is split so the implementation reads through file boundaries and na
 - when the ask config file is missing, the first ask use writes a default persisted config snapshot under `~/.pi/agent/extensions/`
 - legacy root config files move into `~/.pi/agent/extensions/` only when the current config file is absent
 - live config updates can affect an in-progress ask flow immediately
-- `ask:started` and `ask:completed` events are emitted on `pi.events` at flow boundaries in `ask-tool.ts` and `answer-commands.ts`; they are always paired and never emitted on validation failure or in non-interactive mode
+- `ask:started` and `ask:completed` events are emitted on `pi.events` at flow boundaries in `ask-tool.ts` and `answer-commands.ts`; they are always paired (on unexpected errors `ask:completed` carries a cancelled result) and never emitted on validation failure or in non-interactive mode
 
 ## Documentation rule
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -285,6 +285,17 @@ The auto-bundled skill profile at `skills/ask-user/SKILL.md` defines agent-side 
 
 It is advisory only. If there is any conflict, contract + tests win.
 
+## Event bus
+
+pi-ask emits two events on `pi.events` for inter-extension communication:
+
+- **`ask:started`** — emitted after validation, before the ask UI opens. Payload is the validated `AskParams` (`title`, `questions` with prompts/labels/options). Useful for recalling user attention via TTS or notifications.
+- **`ask:completed`** — emitted after the ask flow closes. Payload is `AskResult` (see Output section). Covers all outcomes: submitted, elaborated, and cancelled.
+
+Neither event is emitted on validation failure or in non-interactive mode (`ctx.hasUI === false`).
+
+Consumers use `pi.events.on("ask:started", handler)` and `pi.events.on("ask:completed", handler)` without importing anything from pi-ask.
+
 ## Source of truth
 
 Behavior should be verified against:

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -290,7 +290,7 @@ It is advisory only. If there is any conflict, contract + tests win.
 pi-ask emits two events on `pi.events` for inter-extension communication:
 
 - **`ask:started`** — emitted after validation, before the ask UI opens. Payload is the validated `AskParams` (`title`, `questions` with prompts/labels/options). Useful for recalling user attention via TTS or notifications.
-- **`ask:completed`** — emitted after the ask flow closes. Payload is `AskResult` (see Output section). Covers all outcomes: submitted, elaborated, and cancelled.
+- **`ask:completed`** — emitted after the ask flow closes. Payload is `AskResult` (see Output section). Covers all outcomes: submitted, elaborated, and cancelled. `ask:started` is always followed by `ask:completed`, even when the flow fails unexpectedly (in which case the result has `cancelled: true` and empty answers).
 
 Neither event is emitted on validation failure or in non-interactive mode (`ctx.hasUI === false`).
 

--- a/src/answer-commands.ts
+++ b/src/answer-commands.ts
@@ -264,14 +264,16 @@ async function runReplayCommand(
 }
 
 async function runAskAndSendSubmittedResult(
-	pi: Pick<ExtensionAPI, "sendUserMessage">,
+	pi: Pick<ExtensionAPI, "sendUserMessage" | "events">,
 	ctx: ExtensionContext,
 	params: AskParams,
 	options: { allowFreeform: boolean }
 ): Promise<void> {
+	pi.events.emit("ask:started", params);
 	const result = await withHiddenWorkingRow(ctx, () =>
 		runAskFlow(ctx, params, options)
 	);
+	pi.events.emit("ask:completed", result);
 	if (result.cancelled) {
 		ctx.ui.notify("Ask form cancelled.", "info");
 		return;

--- a/src/answer-commands.ts
+++ b/src/answer-commands.ts
@@ -14,6 +14,7 @@ import {
 	findLatestPayloadInCurrentBranch,
 } from "./ask-payload-store.ts";
 import {
+	cancelledAskResult,
 	invalidPayloadResponse,
 	successfulResponse,
 	validateParams,
@@ -263,22 +264,27 @@ async function runReplayCommand(
 	});
 }
 
-async function runAskAndSendSubmittedResult(
+export async function runAskAndSendSubmittedResult(
 	pi: Pick<ExtensionAPI, "sendUserMessage" | "events">,
 	ctx: ExtensionContext,
 	params: AskParams,
 	options: { allowFreeform: boolean }
 ): Promise<void> {
 	pi.events.emit("ask:started", params);
-	const result = await withHiddenWorkingRow(ctx, () =>
-		runAskFlow(ctx, params, options)
-	);
-	pi.events.emit("ask:completed", result);
-	if (result.cancelled) {
-		ctx.ui.notify("Ask form cancelled.", "info");
-		return;
+	try {
+		const result = await withHiddenWorkingRow(ctx, () =>
+			runAskFlow(ctx, params, options)
+		);
+		pi.events.emit("ask:completed", result);
+		if (result.cancelled) {
+			ctx.ui.notify("Ask form cancelled.", "info");
+			return;
+		}
+		sendAskResult(pi, result, ctx);
+	} catch (error) {
+		pi.events.emit("ask:completed", cancelledAskResult(params));
+		throw error;
 	}
-	sendAskResult(pi, result, ctx);
 }
 
 async function withHiddenWorkingRow<T>(

--- a/src/ask-tool-helpers.ts
+++ b/src/ask-tool-helpers.ts
@@ -81,6 +81,21 @@ export function successfulResponse(result: AskResult) {
 	};
 }
 
+export function cancelledAskResult(params: AskParams): AskResult {
+	return {
+		answers: {},
+		cancelled: true,
+		mode: "submit",
+		questions: params.questions.map((q) => ({
+			id: q.id,
+			label: q.label ?? q.prompt,
+			prompt: q.prompt,
+			type: q.type ?? "single",
+		})),
+		title: params.title,
+	};
+}
+
 type ToolTheme = ExtensionContext["ui"]["theme"];
 
 export function renderAskToolCall(args: unknown, theme: ToolTheme) {

--- a/src/ask-tool.ts
+++ b/src/ask-tool.ts
@@ -42,7 +42,7 @@ export function registerAskTool(pi: ExtensionAPI) {
 }
 
 async function executeAskTool(
-	pi: Pick<ExtensionAPI, "appendEntry">,
+	pi: Pick<ExtensionAPI, "appendEntry" | "events">,
 	toolCallId: string,
 	params: AskParams,
 	_signal: AbortSignal | undefined,
@@ -64,9 +64,11 @@ async function executeAskTool(
 	if (!ctx.hasUI) {
 		return nonInteractiveResponse(validation.state);
 	}
+	pi.events.emit("ask:started", params);
 	ctx.ui.setWorkingVisible(false);
 	try {
 		const result = await runAskFlow(ctx, params);
+		pi.events.emit("ask:completed", result);
 		return successfulResponse(result);
 	} finally {
 		ctx.ui.setWorkingVisible(true);

--- a/src/ask-tool.ts
+++ b/src/ask-tool.ts
@@ -6,6 +6,7 @@ import { appendAskPayload } from "./ask-payload-store.ts";
 import {
 	ASK_TOOL_DESCRIPTION,
 	ASK_TOOL_PROMPT_GUIDELINES,
+	cancelledAskResult,
 	invalidPayloadResponse,
 	nonInteractiveResponse,
 	renderAskToolCall,
@@ -70,6 +71,9 @@ async function executeAskTool(
 		const result = await runAskFlow(ctx, params);
 		pi.events.emit("ask:completed", result);
 		return successfulResponse(result);
+	} catch (error) {
+		pi.events.emit("ask:completed", cancelledAskResult(params));
+		throw error;
 	} finally {
 		ctx.ui.setWorkingVisible(true);
 	}

--- a/tests/answer-commands-events.test.ts
+++ b/tests/answer-commands-events.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runAskAndSendSubmittedResult } from "../src/answer-commands.ts";
+import type { AskParams, AskResult } from "../src/types.ts";
+
+const HAS_UI = "hasUI";
+const TUI_FAILURE_RE = /TUI failure/;
+
+function sampleParams(): AskParams {
+	return {
+		title: "Clarify next step",
+		questions: [
+			{
+				id: "goal",
+				label: "Goal",
+				prompt: "What should I optimize for?",
+				options: [
+					{ value: "speed", label: "Speed" },
+					{ value: "safety", label: "Safety" },
+				],
+			},
+		],
+	};
+}
+
+function makeMockPi() {
+	const emitted: Array<{ channel: string; data: unknown }> = [];
+	return {
+		emitted,
+		pi: {
+			events: {
+				emit(channel: string, data: unknown) {
+					emitted.push({ channel, data });
+				},
+			},
+			sendUserMessage() {
+				// intentional no-op in test
+			},
+		} as never,
+	};
+}
+
+function makeMockCtx(options: {
+	resolvesWith?: AskResult;
+	rejectsWith?: Error;
+}) {
+	return {
+		[HAS_UI]: true,
+		ui: {
+			custom: () =>
+				options.rejectsWith
+					? Promise.reject(options.rejectsWith)
+					: Promise.resolve(options.resolvesWith),
+			setWorkingVisible() {
+				// intentional no-op in test
+			},
+			notify() {
+				// intentional no-op in test
+			},
+		},
+		cwd: "/tmp",
+		isIdle: () => false,
+	} as never;
+}
+
+test("answer-commands emits ask:started and ask:completed on success", async () => {
+	const { emitted, pi } = makeMockPi();
+	const result: AskResult = {
+		answers: {
+			goal: { values: ["speed"], labels: ["Speed"], indices: [0] },
+		},
+		cancelled: false,
+		mode: "submit",
+		questions: [
+			{
+				id: "goal",
+				label: "Goal",
+				prompt: "What should I optimize for?",
+				type: "single",
+			},
+		],
+		title: "Clarify next step",
+	};
+	const ctx = makeMockCtx({ resolvesWith: result });
+
+	await runAskAndSendSubmittedResult(pi, ctx, sampleParams(), {
+		allowFreeform: false,
+	});
+
+	assert.equal(emitted.length, 2);
+	assert.equal(emitted[0].channel, "ask:started");
+	assert.equal(emitted[1].channel, "ask:completed");
+	assert.equal((emitted[1].data as AskResult).cancelled, false);
+	assert.deepEqual((emitted[1].data as AskResult).answers, result.answers);
+});
+
+test("answer-commands emits paired events even when the ask flow fails", async () => {
+	const { emitted, pi } = makeMockPi();
+	const ctx = makeMockCtx({ rejectsWith: new Error("TUI failure") });
+
+	await assert.rejects(
+		() =>
+			runAskAndSendSubmittedResult(pi, ctx, sampleParams(), {
+				allowFreeform: false,
+			}),
+		TUI_FAILURE_RE
+	);
+
+	assert.equal(emitted.length, 2);
+	assert.equal(emitted[0].channel, "ask:started");
+	assert.equal(emitted[1].channel, "ask:completed");
+	assert.equal((emitted[1].data as AskResult).cancelled, true);
+	assert.deepEqual((emitted[1].data as AskResult).answers, {});
+});
+
+test("answer-commands emits completed with cancelled result when flow is cancelled", async () => {
+	const { emitted, pi } = makeMockPi();
+	const cancelledResult: AskResult = {
+		answers: {},
+		cancelled: true,
+		mode: "submit",
+		questions: [
+			{
+				id: "goal",
+				label: "Goal",
+				prompt: "What should I optimize for?",
+				type: "single",
+			},
+		],
+		title: "Clarify next step",
+	};
+	const ctx = makeMockCtx({ resolvesWith: cancelledResult });
+
+	await runAskAndSendSubmittedResult(pi, ctx, sampleParams(), {
+		allowFreeform: false,
+	});
+
+	assert.equal(emitted.length, 2);
+	assert.equal(emitted[0].channel, "ask:started");
+	assert.equal(emitted[1].channel, "ask:completed");
+	assert.equal((emitted[1].data as AskResult).cancelled, true);
+});

--- a/tests/ask-tool.test.ts
+++ b/tests/ask-tool.test.ts
@@ -25,9 +25,15 @@ const noop = () => {
 function registerMockTool() {
 	const tools: Record<string, unknown>[] = [];
 	const entries: Array<{ customType: string; data: unknown }> = [];
+	const emitted: Array<{ channel: string; data: unknown }> = [];
 	registerAskTool({
 		appendEntry(customType: string, data: unknown) {
 			entries.push({ customType, data });
+		},
+		events: {
+			emit(channel: string, data: unknown) {
+				emitted.push({ channel, data });
+			},
 		},
 		registerTool(tool: unknown) {
 			tools.push(tool as Record<string, unknown>);
@@ -35,6 +41,7 @@ function registerMockTool() {
 	} as never);
 	return {
 		entries,
+		emitted,
 		tool: tools[0] as {
 			execute: (...args: any[]) => Promise<any>;
 			renderCall: (args: unknown, theme: any) => { text: string };
@@ -359,4 +366,26 @@ test("ask tool transcript renderers summarize call and cancelled result", () => 
 		theme
 	).text;
 	assert.equal(invalidText, "Invalid input");
+});
+
+test("ask tool emits ask:started and ask:completed events in non-interactive mode", async () => {
+	const { emitted, tool } = registerMockTool();
+
+	await tool.execute("call-1", sampleParams(), undefined, noop, makeCtx(false));
+
+	assert.equal(emitted.length, 0);
+});
+
+test("ask tool does not emit events on validation failure", async () => {
+	const { emitted, tool } = registerMockTool();
+
+	await tool.execute(
+		"call-1",
+		{ title: "X", questions: [] },
+		undefined,
+		noop,
+		makeCtx(true)
+	);
+
+	assert.equal(emitted.length, 0);
 });

--- a/tests/ask-tool.test.ts
+++ b/tests/ask-tool.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { registerAskTool } from "../src/ask-tool.ts";
-import type { AskParams } from "../src/types.ts";
+import type { AskParams, AskResult } from "../src/types.ts";
 
 const NON_INTERACTIVE_MESSAGE_RE =
 	/Needs user input: ask_user requires interactive UI\./;
@@ -368,7 +368,7 @@ test("ask tool transcript renderers summarize call and cancelled result", () => 
 	assert.equal(invalidText, "Invalid input");
 });
 
-test("ask tool emits ask:started and ask:completed events in non-interactive mode", async () => {
+test("ask tool does not emit events in non-interactive mode", async () => {
 	const { emitted, tool } = registerMockTool();
 
 	await tool.execute("call-1", sampleParams(), undefined, noop, makeCtx(false));
@@ -388,4 +388,67 @@ test("ask tool does not emit events on validation failure", async () => {
 	);
 
 	assert.equal(emitted.length, 0);
+});
+
+const TUI_FAILURE_RE = /TUI failure/;
+
+test("ask tool emits ask:started and ask:completed in interactive mode", async () => {
+	const { emitted, tool } = registerMockTool();
+	const mockResult: AskResult = {
+		answers: { goal: { values: ["speed"], labels: ["Speed"], indices: [0] } },
+		cancelled: false,
+		mode: "submit",
+		questions: [
+			{
+				id: "goal",
+				label: "Goal",
+				prompt: "What should I optimize for?",
+				type: "single",
+			},
+		],
+		title: "Clarify next step",
+	};
+	const ctx = {
+		[HAS_UI]: true,
+		ui: {
+			custom: () => Promise.resolve(mockResult),
+			setWorkingVisible() {
+				// intentional no-op in test
+			},
+		},
+		cwd: "/tmp",
+	};
+
+	await tool.execute("call-1", sampleParams(), undefined, noop, ctx);
+
+	assert.equal(emitted.length, 2);
+	assert.equal(emitted[0].channel, "ask:started");
+	assert.equal(emitted[1].channel, "ask:completed");
+	assert.equal((emitted[1].data as AskResult).cancelled, false);
+	assert.deepEqual((emitted[1].data as AskResult).answers, mockResult.answers);
+});
+
+test("ask tool emits paired events even when the ask flow fails", async () => {
+	const { emitted, tool } = registerMockTool();
+	const ctx = {
+		[HAS_UI]: true,
+		ui: {
+			custom: () => Promise.reject(new Error("TUI failure")),
+			setWorkingVisible() {
+				// intentional no-op in test
+			},
+		},
+		cwd: "/tmp",
+	};
+
+	await assert.rejects(
+		() => tool.execute("call-1", sampleParams(), undefined, noop, ctx),
+		TUI_FAILURE_RE
+	);
+
+	assert.equal(emitted.length, 2);
+	assert.equal(emitted[0].channel, "ask:started");
+	assert.equal(emitted[1].channel, "ask:completed");
+	assert.equal((emitted[1].data as AskResult).cancelled, true);
+	assert.deepEqual((emitted[1].data as AskResult).answers, {});
 });


### PR DESCRIPTION
Closes #5

Emit two lifecycle events (`ask:started`, `ask:completed`) on `pi.events` so other extensions can observe ask-flow boundaries.

---

*Generated by Pi agent on behalf of S1M0N38*