### PR TITLE
fix: tolerate code fences and surface empty extraction responses

### DIFF
--- a/src/answer-extraction.ts
+++ b/src/answer-extraction.ts
@@ -203,13 +203,24 @@ async function runExtractionAttempt(options: {
 
 const MAX_EXTRACTED_OPTIONS_PER_QUESTION = 4;
 
-function parseExtractionCandidate(
+const CODE_FENCE_PATTERN = /^```(?:[a-zA-Z0-9_-]+)?\s*\n([\s\S]*?)\n```\s*$/;
+
+export function parseExtractionCandidate(
 	responseText: string
 ):
 	| { ok: true; params: AskParams; issues: string[] }
 	| { ok: false; error: string } {
+	const trimmed = responseText.trim();
+	if (trimmed === "") {
+		return {
+			ok: false,
+			error:
+				"Model returned no text content (possibly reasoning-only output). Configure answer.extractionModels with a model that emits text.",
+		};
+	}
+	const candidate = extractJsonCandidate(trimmed);
 	try {
-		const parsed = JSON.parse(responseText.trim()) as unknown;
+		const parsed = JSON.parse(candidate) as unknown;
 		if (!isAskParamsLike(parsed)) {
 			return { ok: false, error: "root.questions must be an array" };
 		}
@@ -224,6 +235,77 @@ function parseExtractionCandidate(
 			error: error instanceof Error ? error.message : String(error),
 		};
 	}
+}
+
+/**
+ * Normalize an LLM response into a JSON candidate.
+ *
+ * Chat-tuned models commonly wrap structured output in Markdown code fences
+ * or surrounding prose even when the prompt forbids it. This helper hides
+ * those quirks behind the parser interface: it strips a leading/trailing
+ * code fence, and as a last resort extracts the largest balanced JSON object.
+ * Downstream JSON.parse remains the source of truth for validity.
+ */
+function extractJsonCandidate(text: string): string {
+	const unfenced = stripCodeFences(text);
+	if (unfenced.startsWith("{") || unfenced.startsWith("[")) {
+		return unfenced;
+	}
+	return extractBalancedJsonObject(unfenced) ?? unfenced;
+}
+
+function stripCodeFences(text: string): string {
+	const match = text.match(CODE_FENCE_PATTERN);
+	return match ? match[1].trim() : text;
+}
+
+function extractBalancedJsonObject(text: string): string | undefined {
+	const start = text.indexOf("{");
+	if (start === -1) {
+		return;
+	}
+	const end = findMatchingBrace(text, start);
+	return end === -1 ? undefined : text.slice(start, end + 1);
+}
+
+function findMatchingBrace(text: string, start: number): number {
+	let depth = 0;
+	let i = start;
+	while (i < text.length) {
+		const c = text[i];
+		if (c === '"') {
+			i = skipQuotedString(text, i + 1);
+			continue;
+		}
+		if (c === "{") {
+			depth++;
+		} else if (c === "}" && --depth === 0) {
+			return i;
+		}
+		i++;
+	}
+	return -1;
+}
+
+/**
+ * Return the index just past the closing quote of a JSON string that starts
+ * at `fromIndex`. Handles backslash escapes. Returns `text.length` if the
+ * string is unterminated.
+ */
+function skipQuotedString(text: string, fromIndex: number): number {
+	let i = fromIndex;
+	while (i < text.length) {
+		const c = text[i];
+		if (c === "\\") {
+			i += 2;
+			continue;
+		}
+		if (c === '"') {
+			return i + 1;
+		}
+		i++;
+	}
+	return text.length;
 }
 
 function isAskParamsLike(value: unknown): value is AskParams {

--- a/tests/answer-extraction.test.ts
+++ b/tests/answer-extraction.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	collectExtractionBusinessIssues,
+	parseExtractionCandidate,
 	repairExtractionParams,
 	selectExtractionModel,
 } from "../src/answer-extraction.ts";
@@ -123,4 +124,69 @@ test("selectExtractionModel validates fallback model auth", async () => {
 	assert.deepEqual(result, {
 		error: "No auth for fallback chat model: fallback/c.",
 	});
+});
+
+const NO_TEXT_CONTENT_ERROR = /no text content/i;
+const QUESTIONS_MUST_BE_ARRAY_ERROR = /questions must be an array/;
+
+test("parseExtractionCandidate accepts raw JSON", () => {
+	const result = parseExtractionCandidate('{"questions":[]}');
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.params.questions.length, 0);
+	}
+});
+
+test("parseExtractionCandidate strips ```json code fences", () => {
+	const result = parseExtractionCandidate('```json\n{"questions":[]}\n```');
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.params.questions.length, 0);
+	}
+});
+
+test("parseExtractionCandidate strips bare ``` code fences", () => {
+	const result = parseExtractionCandidate('```\n{"questions":[]}\n```');
+	assert.equal(result.ok, true);
+});
+
+test("parseExtractionCandidate extracts JSON from surrounding prose", () => {
+	const input =
+		'Here is the JSON:\n{"questions":[{"id":"x","prompt":"y","options":[{"value":"a","label":"A"}]}]}\nDone.';
+	const result = parseExtractionCandidate(input);
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.params.questions.length, 1);
+	}
+});
+
+test("parseExtractionCandidate handles braces inside string values", () => {
+	const input =
+		'{"questions":[{"id":"x","prompt":"a \\"quoted { brace\\" }","options":[{"value":"a","label":"A"}]}]}';
+	const result = parseExtractionCandidate(input);
+	assert.equal(result.ok, true);
+});
+
+test("parseExtractionCandidate reports empty responses as a distinct error", () => {
+	const result = parseExtractionCandidate("");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.match(result.error, NO_TEXT_CONTENT_ERROR);
+	}
+});
+
+test("parseExtractionCandidate reports whitespace-only responses as empty", () => {
+	const result = parseExtractionCandidate("   \n\t  \n");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.match(result.error, NO_TEXT_CONTENT_ERROR);
+	}
+});
+
+test("parseExtractionCandidate rejects non-object roots", () => {
+	const result = parseExtractionCandidate("[1,2,3]");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.match(result.error, QUESTIONS_MUST_BE_ARRAY_ERROR);
+	}
 });


### PR DESCRIPTION
## Change

`parseExtractionCandidate` now:

- Returns a distinct error when the response is empty or whitespace-only, instead of letting `JSON.parse("")` throw `"Unexpected end of JSON input"`.
- Strips a wrapping Markdown code fence, and as a fallback, extracts the largest balanced `{...}` from surrounding prose.

Exported so the new tests can hit it directly, matching `collectExtractionBusinessIssues` and `repairExtractionParams`.

## Why

`/answer` was failing on every assistant message with `Question extraction did not return valid JSON after retries.` Two causes showed up in instrumented logs:

````
model: anthropic/claude-haiku-4-5
result: parse_error: Unexpected token '`', "```json\n{"... is not valid JSON
response:
```json
{"questions":[]}
```
````

````
model: openai-codex/gpt-5.4-mini
result: parse_error: Unexpected end of JSON input
response: (empty)
````

Haiku extracted correctly and wrapped the result in fences anyway. `gpt-5.4-mini` returned no text content because every `openai-codex` model has `reasoning: true` and `runExtractionAttempt` filters out non-text parts.

## Worth flagging

`selectExtractionModel` does not check `model.reasoning`. A user with ChatGPT-subscription auth and a reasoning model first in `extractionModels` still falls into the no-text path. After this change they get a clear error pointing at config, but skipping reasoning models during selection would avoid the bad pick. Separate PR if you want it.

## Validation

`pnpm test`: 166/166. `pnpm typecheck` and `pnpm check`: clean.

## Disclosure

Written with AI assistance (Claude Opus 4.7).
